### PR TITLE
Fail fast if local::lib is missing

### DIFF
--- a/penv.pl
+++ b/penv.pl
@@ -59,6 +59,9 @@ deactivate () {
     fi
 }
 
+# fail fast if local::lib is missing
+perl -I${HOME}/perl5/lib/perl5 -Mlocal::lib -e ';' || return 1
+
 # unset irrelevant variables
 deactivate nondestructive
 


### PR DESCRIPTION
Try not to have side-effects when we know it's not going to work out,
return error code.
